### PR TITLE
feat: add name claim and group/role mapping of the Gitlab provider

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.21
+FROM mcr.microsoft.com/vscode/devcontainers/go:1-1.22
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -25,11 +25,11 @@ type SessionState struct {
 	Nonce []byte `msgpack:"n,omitempty"`
 
 	// UserInfo
-	Name 			  string   `msgpack:"un,omitempty"`
+	Name              string   `msgpack:"un,omitempty"`
 	Email             string   `msgpack:"e,omitempty"`
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`
-	Role 			  string   `msgpack:"r,omitempty"`
+	Role              string   `msgpack:"r,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
 
 	// Internal helpers, not serialized

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -24,9 +24,12 @@ type SessionState struct {
 
 	Nonce []byte `msgpack:"n,omitempty"`
 
+	// UserInfo
+	Name 			  string   `msgpack:"un,omitempty"`
 	Email             string   `msgpack:"e,omitempty"`
 	User              string   `msgpack:"u,omitempty"`
 	Groups            []string `msgpack:"g,omitempty"`
+	Role 			  string   `msgpack:"r,omitempty"`
 	PreferredUsername string   `msgpack:"pu,omitempty"`
 
 	// Internal helpers, not serialized
@@ -142,6 +145,10 @@ func (s *SessionState) GetClaim(claim string) []string {
 		return []string{s.Email}
 	case "user":
 		return []string{s.User}
+	case "name":
+		return []string{s.Name}
+	case "role":
+		return []string{s.Role}
 	case "groups":
 		groups := make([]string, len(s.Groups))
 		copy(groups, s.Groups)

--- a/providers/gitlab.go
+++ b/providers/gitlab.go
@@ -162,7 +162,7 @@ type gitlabUserinfo struct {
 	Email         string   `json:"email"`
 	EmailVerified bool     `json:"email_verified"`
 	Groups        []string `json:"groups"`
-	Name		  string   `json:"name"`
+	Name          string   `json:"name"`
 }
 
 // function to check if the certain groups contains in the list of groups

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -260,6 +260,8 @@ func (p *ProviderData) buildSessionFromClaims(rawIDToken, accessToken string) (*
 		{p.GroupsClaim, &ss.Groups},
 		// TODO (@NickMeves) Deprecate for dynamic claim to session mapping
 		{"preferred_username", &ss.PreferredUsername},
+		{"name", &ss.Name},
+		{"role", &ss.Role},
 	} {
 		if _, err := extractor.GetClaimInto(c.claim, c.dst); err != nil {
 			return nil, err


### PR DESCRIPTION
## Description
 - adding name claim from the OIDC provider
 - map groups and return as role claim by the Gitlab (hardcoded for Boozt environment)

## Motivation and Context
 - a quick fix to prevent using a middleware proxy to map name and roles for a Rundeck system after the Gitlab OIDC authentication